### PR TITLE
Add support for 4-digit hex colors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use fancy_regex::Regex;
 use tower_lsp::LspService;
 use tower_lsp::Server;
 
-const COLOR_REGEX: &str = r#"(["'])\#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3})\1"#;
+const COLOR_REGEX: &str =
+    r#"(["'])\#([0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\1"#;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Adds support for #RGBA colors.

Added #RGBA to tests as well. Let me know if more are needed.

Tried experimenting with this regex, but it made the code panic.

```
\#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{1}|[0-9a-fA-F]{3}|[0-9a-fA-F]{5})?
```
