### PR TITLE
flake overlay: update pkgs.system to pkgs.stdenv.hostPlatform.system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "uwu_colors"
+name = "uwu-colors"
 version = "0.4.0"
 edition = "2024"
 description = "simple language server to colorize hex color strings via textDocument/documentColor"

--- a/flake.lock
+++ b/flake.lock
@@ -19,7 +19,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "systems": "systems"
       }
     },
     "systems": {
@@ -34,24 +34,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,8 @@
           clippy,
         }:
         buildRustPackage {
-          name = "uwu_colors";
+          pname = "uwu-colors";
+          version = "0.4.0";
 
           nativeBuildInputs = [
             clippy
@@ -38,22 +39,38 @@
           src = lib.cleanSource ./.;
         }
       ) { inherit (pkgs.rustPlatform) buildRustPackage; };
+
+      flakePackageOld = pkgs: (flakePackage pkgs).overrideAttrs {
+        pname = "uwu_colors";
+        postPatch = ''
+          substituteInPlace ./Cargo.toml \
+            --replace-fail "uwu-colors" "uwu_colors"
+        '';
+      };
     in
     {
       overlays = {
         default = final: prev: {
+          uwu-colors = flakePackageOld prev;
+        };
+        uwu-colors = final: prev: {
           uwu-colors = flakePackage prev;
         };
       };
 
       packages = forAllSystems (pkgs: {
-        default = flakePackage pkgs;
+        default = flakePackageOld pkgs;
+        uwu-colors = flakePackage pkgs;
       });
 
       apps = forAllSystems (pkgs: {
         default = {
           type = "app";
-          program = nixpkgs.lib.getExe' (flakePackage pkgs) "uwu_colors";
+          program = nixpkgs.lib.getExe' (flakePackageOld pkgs) "uwu_colors";
+        };
+        uwu-colors = {
+          type = "app";
+          program = nixpkgs.lib.getExe' (flakePackage pkgs) "uwu-colors";
         };
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
   }:
     {
       overlays.default = final: prev: {
-        uwu-colors = self.packages.${final.system}.default;
+        uwu-colors = self.packages.${final.stdenv.hostPlatform.system}.default;
       };
     }
     // utils.lib.eachDefaultSystem


### PR DESCRIPTION
Just because the alias got removed. Nix is getting mad now but yknow probably best to make a pull request in case it breaks more seriously in the future